### PR TITLE
Added crucial command to enable wifi connection in fresh new AGL boots

### DIFF
--- a/docs/AGL/AGL_setup.md
+++ b/docs/AGL/AGL_setup.md
@@ -51,6 +51,7 @@ Inside the `connmanctl` prompt, run the following commands:
 
 * **Connect to your network**
     ```bash
+    agent on
     connect <network_name>
     ```
     (Enter the **Wi-Fi password** when prompted.)


### PR DESCRIPTION
This change adds the ```agent on``` command to the AGL Wi-Fi setup documentation.

On fresh AGL boots, ConnMan requires an active agent to handle authentication for secured Wi-Fi networks. Without enabling the agent, connection attempts may fail with misleading errors such as "Not registered", even when drivers and firmware are correctly loaded.

Including this step ensures a reliable and reproducible Wi-Fi connection process for new systems and avoids unnecessary debugging during initial setup.