### PR TITLE
Sprint 7 Documentation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,15 @@ All documentation is kept inside the [docs/](docs/) folder.
 👥 Team
 | Name            | Responsibilities               |
 |-----------------| ------------------------------ |
-| Hellom          | Hardware Engineer              |
-| Marcelo         | AGL / Kuksa                    |
-| Nicole          | Instrument Cluster             |
+| Hellom          | Hardware / Speedsensor         |
+| Marcelo         | Instrument Cluster             |
 | Vinicius        | ThreadX RTOS                   |
-| Yasmine         | CAN / Kuksa                    |
+| Yasmine         | CAN / Instrument Cluster       |
 
 All progress can be seen in [Projects](https://github.com/orgs/SEAME-pt/projects/83)
 
 ## 🗓️ Sprint Status
-- **Current sprint**: Sprint 6
-- **Period**: January 19 to January 30, 2026
-- **Current Status**: 🟡 In Progress
-- **Goals**: Motor Control Migration and Communication Refinement.
+- **Current sprint**: Sprint 7
+- **Period**: January 31 to February 13, 2026  [31/01/2026] → [13/02/2026]
+- **Current Status**: Finished
+- **Goals**: Modernize Instrument Cluster and TSF Validation

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,4 +38,5 @@ This directory contains all the technical and process-related documentation for 
   - [Sprint 4 Report](./sprints/sprint_4_report.md)
   - [Sprint 5 Report](./sprints/sprint_5_report.md)
   - [Sprint 6 Report](./sprints/sprint_6_report.md)
+  - [Sprint 7 Report](./sprints/sprint_7_report.md)
   - [Sprint Template](./sprints/sprint_template.md)

--- a/docs/sprints/README.md
+++ b/docs/sprints/README.md
@@ -43,6 +43,10 @@ This document serves as a visual **report and planning tool** for Agile progress
 **Duration:** [19/01/2026] → [30/01/2026]
 **Sprint 6:** [Sprint 6 Report](https://github.com/SEAME-pt/Team5_Senna_Tech/blob/main/docs/sprints/sprint_6_report.md)
 
+## 🏁 Sprint 7 — Modernize Instrument Cluster and TSF Validation
+**Duration:** [31/01/2026] → [13/02/2026]
+**Sprint 6:** [Sprint 7 Report](https://github.com/SEAME-pt/Team5_Senna_Tech/blob/main/docs/sprints/sprint_7_report.md)
+
 ---
 
 

--- a/docs/sprints/sprint_7_report.md
+++ b/docs/sprints/sprint_7_report.md
@@ -36,21 +36,22 @@ See [Projects](https://github.com/orgs/SEAME-pt/projects/83/views/1?sliceBy%5Bva
 | **10/02** | Hellom will continue to improve the vehicle hardware organization Vinicius will develop a method to calculate the vehicle's range. Marcelo and Yasmine will continue the design of the new cluster version, by adding new assets such as buttons, traffic signs, warnings, battery and autonomy figures.
 | **11/02** | Hellom will develop an electrical schematic that details all connections between the vehicle components. Vinicius validated the new servo motor by stress tests and will develop a method to calculate the vehicle's range. Marcelo will implement the new cluster version in the car, integrating real temperature data from the Raspberry Pi and the vehicle's estimated range, ensuring it is displayed responsively. Yasmine created the slide presentation detailing the new features, UI/UX design, and functionality developed for the new cluster version and will start the ADAS research, preparing the team to the upcome module.
 | **12/02** | Hellom will continue to develop an electrical schematic that details all connections between the vehicle components. Vinicius and Marcelo will develop a method to detect whether the motor is in reverse throttle and display this information responsively on the cluster. They will also start working on the sprint retrospective presentation. Yasmine will continue the research about ADAS and Carla Simulator.
+| **13/02** | The team finished the sprint, and will prepare the Retrospective presentation.
 
 ---
 
 ## 🧠 Key Achievements
 
-- 
-- 
-- 
-- 
-- 
-- 
+- Cluster redesign with new modular components and a modern dashboard layout
+- Development of unit and integration tests
+- Validation of evidences for TSF structure
+- Reorganization of repository architecture
+- Implementation of new CAN IDs for Emergency Stop and Raspberry–STM32 heartbeat communication
+- Hardware reorganization
 
 ---
 
 ## ⚙️ Pending for next sprint
 
-- 
-- 
+- SSD upgrade for Raspberry Pi
+- Implement Emergency Stop functionality


### PR DESCRIPTION
This PR adds the complete documentation for Sprint 7 (31/01/2026 → 13/02/2026), including daily standup logs, sprint objectives, achievements, and pending tasks.

Main Updates

- Added daily meeting reports (02/02 to 12/02)

- Added Sprint 7 development documentation

- Created sprint_7_report.md

- Updated sprint status in main README

- Updated team responsibilities section

This PR ensures proper tracking of Sprint 7 activities, TSF validation progress, and instrument cluster modernization efforts.