### PR TITLE
+ | added documentation on AGL camera setup.

### DIFF
--- a/docs/AGL/AGL_camera-setup.md
+++ b/docs/AGL/AGL_camera-setup.md
@@ -1,0 +1,128 @@
+# Setting up rpi-libcamera on Raspberry Pi 5 with AGL
+
+## Table of Contents
+
+1. [Problem Overview](#problem-overview)  
+2. [Solution: Using the rpi-libcamera Fork](#solution-using-the-rpi-libcamera-fork)  
+3. [Implementation Structure](#implementation-structure)  
+   1. [Install rpi-libcamera and Dependencies](#install-rpi-libcamera-and-dependencies)  
+   2. [Verify Installation Files](#verify-installation-files)  
+   3. [Test the Camera](#test-the-camera)   
+5. [References](#References)  
+
+---
+
+## Problem Overview
+
+Automotive Grade Linux (AGL) **does not include Raspberry Pi 5 proprietary pipelines** by default, such as `libpisp`.  
+
+Without these pipelines:
+
+- The sensor and ISP (Image Signal Processor) pipeline is missing  
+- IPAs (Image Processing Algorithms) like are unavailable  
+- Applications like OpenCV or any V4L2-based software cannot access `/dev/video*`  
+
+As a result, standard libcamera on AGL **cannot capture frames from Raspberry Pi cameras**.
+
+---
+
+## Solution: Using the rpi-libcamera Fork
+
+The **rpi-libcamera fork** provides:
+
+- Raspberry Pi-specific pipelines (rpi/pisp)  
+- Precompiled IPAs for official sensors (IMX219, IMX708, IMX477, etc.)  
+
+By installing `rpi-libcamera` along with its dependencies, AGL can fully support Raspberry Pi cameras.
+
+---
+
+## Implementation Structure
+
+The implementation consists of three main components:
+
+1. **rpi-camera Recipe (recipes-multimedia/rpi-libcamera/rpi-libcamera_0.5.2bb)**  
+   - Tracks the Raspberry Pi fork of libcamera  
+   - Ensures that using RPi Linux requires `rpi-libcamera`  
+   - Sets `rpi-libcamera` as the preferred provider in AGL builds  
+
+2. **libpisp Recipe (recipes-multimedia/rpi-libcamera/libpisp_1.3.0.bb)**  
+   - Provides the **PISP pipeline handler** for Raspberry Pi5 
+   - Includes prebuilt IPAs for official cameras  
+
+3. **rpicam-apps Recipe (recipes-multimedia/rpicam-apps/rpicam-apps_1.9.1.bb)**  
+   - Replaces standard `libcamera-apps` in the Yocto build for Raspberry Pi  
+   - Utilities provided:
+     - `rpicam-hello` – camera detection and info  
+     - `rpicam-jpeg` – capture JPEG images  
+     - `rpicam-still` – capture raw stills  
+     - `rpicam-vid` – record video  
+
+**Additional Notes on Implementation:**
+
+- Dynamic layers were cleaned:
+  - `libcamera-apps` removed from `dynamic-layers`  
+  - `libcamera_%.bbappend` removed  
+- Preferred provider for `libcamera` is explicitly set to `rpi-libcamera` in `conf/local.conf`  
+
+
+---
+
+
+
+### Install rpi-libcamera and Dependencies into yout build
+
+In the AGL environment:
+
+Add the following recipes to your build in `conf/local.conf`:  
+   - `rpi-camera`  
+   - `libpisp`  
+   - `rpicam-apps` 
+
+### Verify Installation Files after new AGL image builded
+
+Confirm that:
+
+- `rpi-libcamera` contains the `rpi/pisp` pipeline and IPAs  
+- `libpisp` provides the PISP library for Raspberry Pi sensors  
+- `rpicam-apps` provides the camera utilities and assets  
+
+---
+
+### Test the Camera
+
+List available cameras:
+
+```bash
+rpicam-hello --list-cameras
+
+Example output:
+
+0 : imx708_wide_noir [4608x2592 10-bit RGGB]
+    Modes: 'SRGGB10_CSI2P' : 1536x864 [120.13 fps]
+                             2304x1296 [56.03 fps]
+                             4608x2592 [14.35 fps]
+```
+
+                            
+
+Confirms that the pipeline is loaded and the camera is detected
+
+
+
+#### Capture a Frame
+
+Use rpicam-still to capture a single frame:
+
+```
+rpicam-still -o capture.jpg
+```
+
+-o capture.jpg → save captured image to capture.jpg
+
+**This works with the RPi pipeline and IPAs enabled by rpi-libcamera**
+
+
+## References
+
+- Raspberry Pi libcamera fork and PISP pipeline discussion: [meta-raspberrypi PR #1517](https://github.com/agherzan/meta-raspberrypi/pull/1517)  

--- a/docs/AGL/readme.md
+++ b/docs/AGL/readme.md
@@ -59,8 +59,9 @@ This document provides a high-level guide to the available AGL documentation in 
 
 ## 5. AGL_support.md
 
-**Purpose: A general support guide for the AGL environment.
-Content includes:**
+#### Purpose: A general support guide for the AGL environment.
+
+**Content includes:**
 
 - Common issues encountered during development
 
@@ -69,3 +70,21 @@ Content includes:**
 - How to inspect system logs, services, and kernel modules
 
 - Guidelines for adding new hardware support or features
+
+## 6. AGL_camera_setup.md
+
+#### Purpose: Describes the integration and configuration of Raspberry Pi camera support in AGL using the rpi-libcamera fork.
+
+**Content includes:**
+
+- Overview of the problem with standard libcamera in AGL
+
+- Explanation of why the Raspberry Pi fork (rpi-libcamera) is required
+
+- Integration of libpisp for Raspberry Pi 5 PISP pipeline support
+
+- Replacement of libcamera-apps with rpicam-apps
+
+- Yocto recipe structure and preferred provider configuration
+
+- Verification steps to confirm pipeline and IPA loading


### PR DESCRIPTION
This pull request adds comprehensive documentation for configuring Raspberry Pi camera support on Raspberry Pi 5 running Automotive Grade Linux (AGL).
It introduces a new document, AGL_camera_setup.md, detailing the integration of the rpi-libcamera fork required for proper pipeline support.
The documentation explains why the standard AGL libcamera implementation is insufficient due to missing proprietary pipelines such as libpisp.
It describes the Yocto recipe structure, including rpi-libcamera, libpisp, and rpicam-apps.
Configuration steps for setting the preferred provider and cleaning dynamic layers are also covered.
The guide includes instructions for verifying pipeline and IPA installation after building the AGL image.
Practical testing commands are provided to list cameras and capture frames using rpicam utilities.
A reference to meta-raspberrypi PR #1517 is included for additional technical background.
Additionally, the main AGL documentation index was updated to reference the new camera setup guide.

#close 206